### PR TITLE
Set revalidation period to one hour

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -96,14 +96,17 @@ export default function Home(props) {
 }
 
 export async function getStaticProps() {
+  console.log('getStaticProps');
   return {
     props: {
       initialData: await getData()
-    }
+    },
+    revalidate: 3600,
   }
 }
 
 async function getData() {
+  console.log('getData - should only run on server');
   const client = getApolloServer();
 
   let errored = false;

--- a/pages/index.js
+++ b/pages/index.js
@@ -96,7 +96,6 @@ export default function Home(props) {
 }
 
 export async function getStaticProps() {
-  console.log('getStaticProps');
   return {
     props: {
       initialData: await getData()
@@ -106,7 +105,6 @@ export async function getStaticProps() {
 }
 
 async function getData() {
-  console.log('getData - should only run on server');
   const client = getApolloServer();
 
   let errored = false;


### PR DESCRIPTION
The static build would never rebuild, since revalidate wasn't set.  Now, when the request comes more than one hour from the previous build, a rebuild will occur.